### PR TITLE
Fix ruby >= 3.2.0 compatibility issue

### DIFF
--- a/lib/jenncad/commands.rb
+++ b/lib/jenncad/commands.rb
@@ -12,7 +12,7 @@ module JennCad
       end
 
       def check_executable(file)
-        return true if File.exists?(file)
+        return true if File.exist?(file)
         # this is not too smart at the moment
         puts "cannot find executable #{file}"
         nil
@@ -110,7 +110,7 @@ module JennCad
         dir = Dir.pwd.split("/").last
         executable = underscore(dir)+".rb"
         executable_class = camelize(dir)
-        unless File.exists?(executable)
+        unless File.exist?(executable)
           puts "Could not find #{executable}. Are you in a JennCad project directory?"
           exit
         end

--- a/lib/jenncad/profile_loader.rb
+++ b/lib/jenncad/profile_loader.rb
@@ -13,7 +13,7 @@ module JennCad
     end
 
     def load_profile
-      if File.exists?(profile_path)
+      if File.exist?(profile_path)
         require profile_path
         check_profile
       else


### PR DESCRIPTION
Seems like `File.exists?` method has been removed from ruby >= 3.2.0.